### PR TITLE
Track package imports and aliases

### DIFF
--- a/rules/blacklist.go
+++ b/rules/blacklist.go
@@ -27,7 +27,7 @@ type BlacklistImport struct {
 
 func (r *BlacklistImport) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err error) {
 	if node, ok := n.(*ast.ImportSpec); ok {
-		if r.Path == node.Path.Value {
+		if r.Path == node.Path.Value && node.Name.String() != "_" {
 			return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
 		}
 	}

--- a/rules/blacklist_test.go
+++ b/rules/blacklist_test.go
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	gas "github.com/GoASTScanner/gas/core"
+	"testing"
+)
+
+const initOnlyImportSrc = `
+package main
+import (
+	_ "crypto/md5"
+	"fmt"
+)
+func main() {
+	for _, arg := range os.Args {
+		fmt.Println(arg)
+	}
+}`
+
+func TestInitOnlyImport(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewBlacklist_crypto_md5(config))
+	issues := gasTestRunner(initOnlyImportSrc, analyzer)
+	checkTestResults(t, issues, 0, "")
+}


### PR DESCRIPTION
There has been a number of false positives using the regexp matching. This approach attempts to resolve it in a backwards compatible way. The 'Uses' map does not appear to be populated with the same level of detail in Go 1.5 so using GetCallObject was not sufficient. 

Additionally this should address the blacklist imports issue where we were reporting an error for initialization only imports. 