### PR TITLE
Handle inbalanced declaration of constants

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -58,7 +58,7 @@ func (r *Credentials) matchGenDecl(decl *ast.GenDecl, ctx *gas.Context) (*gas.Is
 	for _, spec := range decl.Specs {
 		if valueSpec, ok := spec.(*ast.ValueSpec); ok {
 			for index, ident := range valueSpec.Names {
-				if r.pattern.MatchString(ident.Name) {
+				if r.pattern.MatchString(ident.Name) && valueSpec.Values != nil {
 					// const foo, bar = "same value"
 					if len(valueSpec.Values) <= index {
 						index = len(valueSpec.Values) - 1

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -59,6 +59,10 @@ func (r *Credentials) matchGenDecl(decl *ast.GenDecl, ctx *gas.Context) (*gas.Is
 		if valueSpec, ok := spec.(*ast.ValueSpec); ok {
 			for index, ident := range valueSpec.Names {
 				if r.pattern.MatchString(ident.Name) {
+					// const foo, bar = "same value"
+					if len(valueSpec.Values) <= index {
+						index = len(valueSpec.Values) - 1
+					}
 					if _, ok := valueSpec.Values[index].(*ast.BasicLit); ok {
 						return gas.NewIssue(ctx, decl, r.What, r.Severity, r.Confidence), nil
 					}

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -98,3 +98,16 @@ func TestHardcodedConstantMulti(t *testing.T) {
 
 	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
 }
+
+func TestHardecodedVarsNotAssigned(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewHardcodedCredentials(config))
+	issues := gasTestRunner(`
+		package main 
+		var password string
+		func init() {
+			password = "this is a secret string"
+		}`, analyzer)
+	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
+}

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -79,3 +79,22 @@ func TestHardcodedConstant(t *testing.T) {
 
 	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
 }
+
+func TestHardcodedConstantMulti(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewHardcodedCredentials(config))
+
+	issues := gasTestRunner(`
+		package samples
+
+		import "fmt"
+
+		const username, password = "secret"
+
+		func main() {
+			fmt.Println("Doing something with: ", username, password)
+		}`, analyzer)
+
+	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
+}


### PR DESCRIPTION
The following code would create a panic condition:

const foo, bar = "some thing"

Fixes #84