### PR TITLE
adding support for arbitrary paths with ellipses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 *.prof
 
 .DS_Store
+
+.vscode

--- a/filelist_test.go
+++ b/filelist_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_newFileList(t *testing.T) {
+	type args struct {
+		paths []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *fileList
+	}{
+		{
+			name: "nil paths",
+			args: args{paths: nil},
+			want: &fileList{patterns: map[string]struct{}{}},
+		},
+		{
+			name: "empty paths",
+			args: args{paths: []string{}},
+			want: &fileList{patterns: map[string]struct{}{}},
+		},
+		{
+			name: "have paths",
+			args: args{paths: []string{"*_test.go"}},
+			want: &fileList{patterns: map[string]struct{}{
+				"*_test.go": struct{}{},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		if got := newFileList(tt.args.paths...); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%q. newFileList() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_fileList_String(t *testing.T) {
+	type fields struct {
+		patterns []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "nil patterns",
+			fields: fields{patterns: nil},
+			want:   "",
+		},
+		{
+			name:   "empty patterns",
+			fields: fields{patterns: []string{}},
+			want:   "",
+		},
+		{
+			name:   "one pattern",
+			fields: fields{patterns: []string{"foo"}},
+			want:   "foo",
+		},
+		{
+			name:   "two patterns",
+			fields: fields{patterns: []string{"foo", "bar"}},
+			want:   "foo, bar",
+		},
+	}
+	for _, tt := range tests {
+		f := newFileList(tt.fields.patterns...)
+		if got := f.String(); got != tt.want {
+			t.Errorf("%q. fileList.String() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_fileList_Set(t *testing.T) {
+	type fields struct {
+		patterns []string
+	}
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]struct{}
+		wantErr bool
+	}{
+		{
+			name:    "add empty path",
+			fields:  fields{patterns: nil},
+			args:    args{path: ""},
+			want:    map[string]struct{}{},
+			wantErr: false,
+		},
+		{
+			name:   "add path to nil patterns",
+			fields: fields{patterns: nil},
+			args:   args{path: "foo"},
+			want: map[string]struct{}{
+				"foo": struct{}{},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "add path to empty patterns",
+			fields: fields{patterns: []string{}},
+			args:   args{path: "foo"},
+			want: map[string]struct{}{
+				"foo": struct{}{},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "add path to populated patterns",
+			fields: fields{patterns: []string{"foo"}},
+			args:   args{path: "bar"},
+			want: map[string]struct{}{
+				"foo": struct{}{},
+				"bar": struct{}{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		f := newFileList(tt.fields.patterns...)
+		if err := f.Set(tt.args.path); (err != nil) != tt.wantErr {
+			t.Errorf("%q. fileList.Set() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+		if !reflect.DeepEqual(f.patterns, tt.want) {
+			t.Errorf("%q. got state fileList.patterns = %v, want state %v", tt.name, f.patterns, tt.want)
+		}
+	}
+}
+
+func Test_fileList_Contains(t *testing.T) {
+	type fields struct {
+		patterns []string
+	}
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "nil patterns",
+			fields: fields{patterns: nil},
+			args:   args{path: "foo"},
+			want:   false,
+		},
+		{
+			name:   "empty patterns",
+			fields: fields{patterns: nil},
+			args:   args{path: "foo"},
+			want:   false,
+		},
+		{
+			name:   "one pattern, no wildcard, no match",
+			fields: fields{patterns: []string{"foo"}},
+			args:   args{path: "bar"},
+			want:   false,
+		},
+		{
+			name:   "one pattern, no wildcard, match",
+			fields: fields{patterns: []string{"foo"}},
+			args:   args{path: "foo"},
+			want:   true,
+		},
+		{
+			name:   "one pattern, wildcard prefix, match",
+			fields: fields{patterns: []string{"*foo"}},
+			args:   args{path: "foo"},
+			want:   true,
+		},
+		{
+			name:   "one pattern, wildcard suffix, match",
+			fields: fields{patterns: []string{"foo*"}},
+			args:   args{path: "foo"},
+			want:   true,
+		},
+		{
+			name:   "one pattern, wildcard both ends, match",
+			fields: fields{patterns: []string{"*foo*"}},
+			args:   args{path: "foo"},
+			want:   true,
+		},
+		{
+			name:   "default test match 1",
+			fields: fields{patterns: []string{"*_test.go"}},
+			args:   args{path: "foo_test.go"},
+			want:   true,
+		},
+		{
+			name:   "default test match 2",
+			fields: fields{patterns: []string{"*_test.go"}},
+			args:   args{path: "bar/foo_test.go"},
+			want:   true,
+		},
+		{
+			name:   "default test match 3",
+			fields: fields{patterns: []string{"*_test.go"}},
+			args:   args{path: "/bar/foo_test.go"},
+			want:   true,
+		},
+		{
+			name:   "default test match 4",
+			fields: fields{patterns: []string{"*_test.go"}},
+			args:   args{path: "baz/bar/foo_test.go"},
+			want:   true,
+		},
+		{
+			name:   "default test match 5",
+			fields: fields{patterns: []string{"*_test.go"}},
+			args:   args{path: "/baz/bar/foo_test.go"},
+			want:   true,
+		},
+		{
+			name:   "many patterns, no match",
+			fields: fields{patterns: []string{"*_one.go", "*_two.go"}},
+			args:   args{path: "/baz/bar/foo_test.go"},
+			want:   false,
+		},
+		{
+			name:   "many patterns, match",
+			fields: fields{patterns: []string{"*_one.go", "*_two.go", "*_test.go"}},
+			args:   args{path: "/baz/bar/foo_test.go"},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		f := newFileList(tt.fields.patterns...)
+		if got := f.Contains(tt.args.path); got != tt.want {
+			t.Errorf("%q. fileList.Contains() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func Test_shouldInclude(t *testing.T) {
+	type args struct {
+		path     string
+		excluded *fileList
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "non .go file",
+			args: args{
+				path:     "thing.txt",
+				excluded: newFileList(),
+			},
+			want: false,
+		},
+		{
+			name: ".go file, not excluded",
+			args: args{
+				path:     "thing.go",
+				excluded: newFileList(),
+			},
+			want: true,
+		},
+		{
+			name: ".go file, excluded",
+			args: args{
+				path:     "thing.go",
+				excluded: newFileList("thing.go"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		if got := shouldInclude(tt.args.path, tt.args.excluded); got != tt.want {
+			t.Errorf("%q. shouldInclude() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,0 +1,2 @@
+# Import path             | revision                               | Repository(optional)
+github.com/ryanuber/go-glob 572520ed46dbddaed19ea3d9541bdd0494163693

--- a/vendor/github.com/ryanuber/go-glob/LICENSE
+++ b/vendor/github.com/ryanuber/go-glob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ryan Uber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ryanuber/go-glob/glob.go
+++ b/vendor/github.com/ryanuber/go-glob/glob.go
@@ -1,0 +1,51 @@
+package glob
+
+import "strings"
+
+// The character which is treated like a glob
+const GLOB = "*"
+
+// Glob will test a string pattern, potentially containing globs, against a
+// subject string. The result is a simple true/false, determining whether or
+// not the glob pattern matched the subject text.
+func Glob(pattern, subj string) bool {
+	// Empty pattern can only match empty subject
+	if pattern == "" {
+		return subj == pattern
+	}
+
+	// If the pattern _is_ a glob, it matches everything
+	if pattern == GLOB {
+		return true
+	}
+
+	parts := strings.Split(pattern, GLOB)
+
+	if len(parts) == 1 {
+		// No globs in pattern, so test for equality
+		return subj == pattern
+	}
+
+	leadingGlob := strings.HasPrefix(pattern, GLOB)
+	trailingGlob := strings.HasSuffix(pattern, GLOB)
+	end := len(parts) - 1
+
+	// Check the first section. Requires special handling.
+	if !leadingGlob && !strings.HasPrefix(subj, parts[0]) {
+		return false
+	}
+
+	// Go over the middle parts and ensure they match.
+	for i := 1; i < end; i++ {
+		if !strings.Contains(subj, parts[i]) {
+			return false
+		}
+
+		// Trim evaluated text from subj as we loop over the pattern.
+		idx := strings.Index(subj, parts[i]) + len(parts[i])
+		subj = subj[idx:]
+	}
+
+	// Reached the last section. Requires special handling.
+	return trailingGlob || strings.HasSuffix(subj, parts[end])
+}


### PR DESCRIPTION
Changes:

- any path suffixed with `/...` will now work.
- changes to fileList and how the `-skip` values are handled necessary to support this.
- Golang does not support arbitrary length globbing in filepaths so inclusion of go-glob for simple string glob matching on `-skip` paths.
- Addition of vndr tool to manage dependencies.
- fixed capitalization of `filelist`. Some comments had `fileList` and it's technically 2 words so updating per Go defacto style conventions to `fileList`.

I'm a big fan of including the vendor directory as it protects projects from dependencies becoming unavailable. This isn't my project though so if you don't want it, or want a tool other than `vndr`, just let me know and I'll update.

~~Still working on some tests, will remove WIP later today once I've finished.~~