### PR TITLE
Reduce logging messages a tad

### DIFF
--- a/filelist.go
+++ b/filelist.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"log"
 	"strings"
 
 	"github.com/ryanuber/go-glob"
@@ -57,11 +56,11 @@ func (f *fileList) Set(path string) error {
 func (f fileList) Contains(path string) bool {
 	for p := range f.patterns {
 		if glob.Glob(p, path) {
-			log.Printf("excluding: %s\n", path)
+			logger.Printf("skipping: %s\n", path)
 			return true
 		}
 	}
-	log.Printf("including: %s\n", path)
+	//log.Printf("including: %s\n", path)
 	return false
 }
 

--- a/filelist.go
+++ b/filelist.go
@@ -56,7 +56,9 @@ func (f *fileList) Set(path string) error {
 func (f fileList) Contains(path string) bool {
 	for p := range f.patterns {
 		if glob.Glob(p, path) {
-			logger.Printf("skipping: %s\n", path)
+			if logger != nil {
+				logger.Printf("skipping: %s\n", path)
+			}
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -167,11 +167,11 @@ func main() {
 	tools := newUtils()
 	flag.Var(tools, "tool", "GAS utilities to assist with rule development")
 
+	// Setup logging
+	logger = log.New(os.Stderr, "[gas] ", log.LstdFlags)
+
 	// Parse command line arguments
 	flag.Parse()
-
-	// Setup logging
-	logger = log.New(os.Stderr, "[gas]", log.LstdFlags)
 
 	// Ensure at least one file was specified
 	if flag.NArg() == 0 {
@@ -195,6 +195,7 @@ func main() {
 	toAnalyze := getFilesToAnalyze(flag.Args(), excluded)
 
 	for _, file := range toAnalyze {
+		logger.Printf("scanning \"%s\"\n", file)
 		if err := analyzer.Process(file); err != nil {
 			logger.Fatal(err)
 		}
@@ -226,10 +227,10 @@ func main() {
 
 // getFilesToAnalyze lists all files
 func getFilesToAnalyze(paths []string, excluded *fileList) []string {
-	log.Println("getFilesToAnalyze: start")
+	//log.Println("getFilesToAnalyze: start")
 	var toAnalyze []string
 	for _, path := range paths {
-		log.Printf("getFilesToAnalyze: processing \"%s\"\n", path)
+		//log.Printf("getFilesToAnalyze: processing \"%s\"\n", path)
 		// get the absolute path before doing anything else
 		path, err := filepath.Abs(path)
 		if err != nil {
@@ -257,7 +258,7 @@ func getFilesToAnalyze(paths []string, excluded *fileList) []string {
 			}
 		}
 	}
-	log.Println("getFilesToAnalyze: end")
+	//log.Println("getFilesToAnalyze: end")
 	return toAnalyze
 }
 


### PR DESCRIPTION
Only need to log if we're skipping a file or if we're processing it.
Should also use the [gas] prefix to aid filtering.