### PR TITLE
Ensure hardcoded credentials check only considers constant strings

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -41,7 +41,7 @@ func (r *Credentials) matchAssign(assign *ast.AssignStmt, ctx *gas.Context) (*ga
 		if ident, ok := i.(*ast.Ident); ok {
 			if r.pattern.MatchString(ident.Name) {
 				for _, e := range assign.Rhs {
-					if _, ok := e.(*ast.BasicLit); ok {
+					if rhs, ok := e.(*ast.BasicLit); ok && rhs.Kind == token.STRING {
 						return gas.NewIssue(ctx, assign, r.What, r.Severity, r.Confidence), nil
 					}
 				}
@@ -63,7 +63,7 @@ func (r *Credentials) matchGenDecl(decl *ast.GenDecl, ctx *gas.Context) (*gas.Is
 					if len(valueSpec.Values) <= index {
 						index = len(valueSpec.Values) - 1
 					}
-					if _, ok := valueSpec.Values[index].(*ast.BasicLit); ok {
+					if rhs, ok := valueSpec.Values[index].(*ast.BasicLit); ok && rhs.Kind == token.STRING {
 						return gas.NewIssue(ctx, decl, r.What, r.Severity, r.Confidence), nil
 					}
 				}

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -111,3 +111,20 @@ func TestHardecodedVarsNotAssigned(t *testing.T) {
 		}`, analyzer)
 	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
 }
+
+func TestHardcodedConstInteger(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewHardcodedCredentials(config))
+	issues := gasTestRunner(`
+		package main
+
+		const (
+			ATNStateSomethingElse = 1,
+			ATNStateTokenStart = 42,
+		)
+		func main() {
+			println(ATNStateTokenStart)
+		}`, analyzer)
+	checkTestResults(t, issues, 0, "Potential hardcoded credentials")
+}

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -120,11 +120,27 @@ func TestHardcodedConstInteger(t *testing.T) {
 		package main
 
 		const (
-			ATNStateSomethingElse = 1,
-			ATNStateTokenStart = 42,
+			ATNStateSomethingElse = 1
+			ATNStateTokenStart = 42
 		)
 		func main() {
 			println(ATNStateTokenStart)
 		}`, analyzer)
 	checkTestResults(t, issues, 0, "Potential hardcoded credentials")
+}
+
+func TestHardcodedConstString(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewHardcodedCredentials(config))
+	issues := gasTestRunner(`
+		package main
+
+		const (
+			ATNStateTokenStart = "foo bar"
+		)
+		func main() {
+			println(ATNStateTokenStart)
+		}`, analyzer)
+	checkTestResults(t, issues, 1, "Potential hardcoded credentials")
 }


### PR DESCRIPTION
This is a partial bandaid fix for #108 until we introduce the entropy check suggested in #105.