### PR TITLE
Temporarily disable typechecker fatal error

### DIFF
--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -16,7 +16,6 @@
 package core
 
 import (
-	"fmt"
 	"go/ast"
 	"go/importer"
 	"go/parser"
@@ -126,7 +125,10 @@ func (gas *Analyzer) process(filename string, source interface{}) error {
 		conf := types.Config{Importer: importer.Default()}
 		gas.context.Pkg, err = conf.Check("pkg", gas.context.FileSet, []*ast.File{root}, gas.context.Info)
 		if err != nil {
-			return fmt.Errorf(`Error during type checking: "%s"`, err)
+			// TODO(gm) Type checker not currently considering all files within a package
+			// see: issue #113
+			gas.logger.Printf(`Error during type checking: "%s"`, err)
+			err = nil
 		}
 
 		gas.context.Imports = NewImportInfo()


### PR DESCRIPTION
It seems that the typechecker isn't considering the entire package
fileset in the current way that gas is processing projects. This leads
to cases where types that are defined in one file aren't known about
when gas is processing other files within that module.

A redesign is needed, this is a temporary fix to return to old
behaviour.

Related to #113