### PR TITLE
Correct bad test cases and intermitent failure

### DIFF
--- a/filelist.go
+++ b/filelist.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/ryanuber/go-glob"
@@ -41,6 +42,7 @@ func (f *fileList) String() string {
 	for p := range f.patterns {
 		ps = append(ps, p)
 	}
+	sort.Strings(ps)
 	return strings.Join(ps, ", ")
 }
 

--- a/filelist_test.go
+++ b/filelist_test.go
@@ -65,8 +65,8 @@ func Test_fileList_String(t *testing.T) {
 		},
 		{
 			name:   "two patterns",
-			fields: fields{patterns: []string{"foo", "bar"}},
-			want:   "foo, bar",
+			fields: fields{patterns: []string{"bar", "foo"}},
+			want:   "bar, foo",
 		},
 	}
 	for _, tt := range tests {

--- a/rules/blacklist_test.go
+++ b/rules/blacklist_test.go
@@ -22,6 +22,7 @@ package main
 import (
 	_ "crypto/md5"
 	"fmt"
+	"os"
 )
 func main() {
 	for _, arg := range os.Args {

--- a/rules/nosec_test.go
+++ b/rules/nosec_test.go
@@ -49,7 +49,7 @@ func TestNosecBlock(t *testing.T) {
 		`package main
 		import (
 		"os" 
-		"os/exect"
+		"os/exec"
 	)
 
 	func main() {

--- a/rules/sql_test.go
+++ b/rules/sql_test.go
@@ -89,8 +89,6 @@ func TestSQLInjectionFalsePositiveA(t *testing.T) {
         package main
         import (
                 "database/sql"
-                "fmt"
-                "os"
                 //_ "github.com/mattn/go-sqlite3"
         )
 
@@ -125,8 +123,6 @@ func TestSQLInjectionFalsePositiveB(t *testing.T) {
         package main
         import (
                 "database/sql"
-                "fmt"
-                "os"
                 //_ "github.com/mattn/go-sqlite3"
         )
 
@@ -161,8 +157,6 @@ func TestSQLInjectionFalsePositiveC(t *testing.T) {
         package main
         import (
                 "database/sql"
-                "fmt"
-                "os"
                 //_ "github.com/mattn/go-sqlite3"
         )
 
@@ -197,8 +191,6 @@ func TestSQLInjectionFalsePositiveD(t *testing.T) {
         package main
         import (
                 "database/sql"
-                "fmt"
-                "os"
                 //_ "github.com/mattn/go-sqlite3"
         )
 


### PR DESCRIPTION
The filelist test was non-deterministic and causing intermittent
failures due to ordering. This change will ensure that the file list
returns an ordered list of files in the String() method now.

Additionally there were a number of test cases that the sample code
was incorrect, or would not compile. These have also been corrected.