### PR TITLE
Add support for partial path match in the skip option

### DIFF
--- a/filelist.go
+++ b/filelist.go
@@ -57,14 +57,24 @@ func (f *fileList) Set(path string) error {
 
 func (f fileList) Contains(path string) bool {
 	for p := range f.patterns {
-		if glob.Glob(p, path) {
-			if logger != nil {
-				logger.Printf("skipping: %s\n", path)
+		if strings.Contains(p, glob.GLOB) {
+			if glob.Glob(p, path) {
+				if logger != nil {
+					logger.Printf("skipping: %s\n", path)
+				}
+				return true
 			}
-			return true
+		} else {
+			// check if only a sub-folder of the path is excluded
+			if strings.Contains(path, p) {
+				if logger != nil {
+					logger.Printf("skipping: %s\n", path)
+				}
+				return true
+			}
+
 		}
 	}
-	//log.Printf("including: %s\n", path)
 	return false
 }
 

--- a/filelist_test.go
+++ b/filelist_test.go
@@ -235,6 +235,12 @@ func Test_fileList_Contains(t *testing.T) {
 			args:   args{path: "/baz/bar/foo_test.go"},
 			want:   true,
 		},
+		{
+			name:   "sub-folder, match",
+			fields: fields{patterns: []string{"vendor"}},
+			args:   args{path: "/baz/vendor/bar/foo_test.go"},
+			want:   true,
+		},
 	}
 	for _, tt := range tests {
 		f := newFileList(tt.fields.patterns...)

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	//  Exclude files
 	excluded := newFileList("*_test.go")
-	flag.Var(excluded, "skip", "File pattern to exclude from scan. Uses simple * globs and requires full match")
+	flag.Var(excluded, "skip", "File pattern to exclude from scan. Uses simple * globs and requires full or partial match")
 
 	incRules := ""
 	flag.StringVar(&incRules, "include", "", "Comma separated list of rules IDs to include. (see rule list)")


### PR DESCRIPTION
This is a fix for issue #124. The `skip` option is extended to support partial path match. Currently it is possible to exclude the vendor folder with this pattern only:

```
gas -skip "*vendor*" ./..
```

I extended the `fileList` to support also partial paths like this:

```
gas -skip vendor ./..
``` 