### PR TITLE
Add a rule which audits the use of math/big.Int.Exp function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ or to specify a set of rules to explicitly exclude using the '-exclude=' flag.
   - G102: Bind to all interfaces
   - G103: Audit the use of unsafe block
   - G104: Audit errors not checked
+  - G105: Audit the use of math/big.Int.Exp
   - G201: SQL query construction using format string
   - G202: SQL query construction using string concatenation
   - G203: Use of unescaped data in HTML templates

--- a/rulelist.go
+++ b/rulelist.go
@@ -34,6 +34,7 @@ func GetFullRuleList() map[string]RuleInfo {
 		"G102": RuleInfo{"Bind to all interfaces", rules.NewBindsToAllNetworkInterfaces},
 		"G103": RuleInfo{"Audit the use of unsafe block", rules.NewUsingUnsafe},
 		"G104": RuleInfo{"Audit errors not checked", rules.NewNoErrorCheck},
+		"G105": RuleInfo{"Audit the use of big.Exp function", rules.NewUsingBigExp},
 
 		// injection
 		"G201": RuleInfo{"SQL query construction using format string", rules.NewSqlStrFormat},

--- a/rules/big.go
+++ b/rules/big.go
@@ -1,0 +1,44 @@
+// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	gas "github.com/GoASTScanner/gas/core"
+	"go/ast"
+)
+
+type UsingBigExp struct {
+	gas.MetaData
+	pkg   string
+	calls []string
+}
+
+func (r *UsingBigExp) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err error) {
+	if _, matches := gas.MatchCallByPackage(n, c, r.pkg, r.calls...); matches {
+		return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
+	}
+	return nil, nil
+}
+func NewUsingBigExp(conf map[string]interface{}) (gas.Rule, []ast.Node) {
+	return &UsingBigExp{
+		pkg:   "big",
+		calls: []string{"Exp"},
+		MetaData: gas.MetaData{
+			What:       "Use of big.Exp call should be audited for modulus == 0",
+			Severity:   gas.Low,
+			Confidence: gas.High,
+		},
+	}, []ast.Node{(*ast.CallExpr)(nil)}
+}


### PR DESCRIPTION
The big.Int.Exp might lead to DoS attacks if is used with a modulus equal with zero.

More details: https://www.cryptologie.net/article/347/my-first-cve-o-common-vulnerabilities-and-exposures/