### PR TITLE
Adding Docker container and updating README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-# Builds the Gas scanner with 'docker build' command, and runs Gas on all Go
-# files in your current directory with 'docker run' command.
-#
 # Docker version must be 17.05 or higher to allow multistage build
-#
+# See build and run instructions in README.md
 
+# Builds Gas for utilization
 FROM golang:1.8.1-alpine as builder
 ENV workspace /go/src/github.com/GoASTScanner/gas
+ENV GOPATH /go
 COPY . $workspace
 WORKDIR $workspace
 
 RUN go vet $(go list ./... | grep -v /vendor/)
 RUN CGO_ENABLED=0 go build -o gas .
 
-FROM alpine:3.6
+########################################################
 
-LABEL MAINTAINER="David Graves <david.graves@hpe.com>"
+# Runs Gas on all Go files in the current directory when 
+# 'docker run' command in README is given
+FROM alpine:3.6
 
 COPY --from=builder /go/src/github.com/GoASTScanner/gas/gas /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Builds the Gas scanner with 'docker build' command, and runs Gas on all Go
+# files in your current directory with 'docker run' command.
+#
+# Docker version must be 17.05 or higher to allow multistage build
+#
+
+FROM golang:1.8.1-alpine as builder
+ENV workspace /go/src/github.com/GoASTScanner/gas
+COPY . $workspace
+WORKDIR $workspace
+
+RUN go vet $(go list ./... | grep -v /vendor/)
+RUN CGO_ENABLED=0 go build -o gas .
+
+FROM alpine:3.6
+
+LABEL MAINTAINER="David Graves <david.graves@hpe.com>"
+
+COPY --from=builder /go/src/github.com/GoASTScanner/gas/gas /
+
+# Mounted directory should be placed into the workdir
+CMD /gas $(find . -path ./vendor -prune -o -type f -name "*.go")

--- a/README.md
+++ b/README.md
@@ -112,3 +112,20 @@ file. The output format is controlled by the '-fmt' flag, and the output file is
 # Write output in json format to results.json
 $ gas -fmt=json -out=results.json *.go
 ```
+
+### Docker container
+
+A Dockerfile is included with the Gas source code to provide a container that 
+allows users to easily run Gas on their code. It builds Gas, then runs it on 
+all Go files in your current directory. Use the following commands to build 
+and run locally:
+
+To build: (run command in cloned Gas source code directory)
+          docker build --build-arg http_proxy --build-arg https_proxy
+          --build-arg no_proxy -t goastscanner/gas:latest .
+
+To run:  (run command in desired directory with Go files)
+          docker run -v $PWD:$PWD --workdir $PWD goastscanner/gas:latest
+
+Note: Docker version 17.05 or later is required (to permit multistage build).
+```


### PR DESCRIPTION
This container can be built and run locally, in order to provide a simple way for users to run Gas on their code. The README has been updated to give information and provide build/run commands.