### PR TITLE
Add Fprint, Fprintf, Fprintln to NoErrorCheck whitelist

### DIFF
--- a/rules/errors.go
+++ b/rules/errors.go
@@ -15,9 +15,10 @@
 package rules
 
 import (
-	gas "github.com/GoASTScanner/gas/core"
 	"go/ast"
 	"go/types"
+
+	gas "github.com/GoASTScanner/gas/core"
 )
 
 type NoErrorCheck struct {
@@ -75,7 +76,7 @@ func NewNoErrorCheck(conf map[string]interface{}) (gas.Rule, []ast.Node) {
 	// black list instead.
 	whitelist := gas.NewCallList()
 	whitelist.AddAll("bytes.Buffer", "Write", "WriteByte", "WriteRune", "WriteString")
-	whitelist.AddAll("fmt", "Print", "Printf", "Println")
+	whitelist.AddAll("fmt", "Print", "Printf", "Println", "Fprint", "Fprintf", "Fprintln")
 	whitelist.Add("io.PipeWriter", "CloseWithError")
 
 	if configured, ok := conf["G104"]; ok {


### PR DESCRIPTION
I think add `Fprint*` is a good idea.
I'm using it to handle error such as:
```go
if err != nil {
  fmt.Fprintln(os.Stderr, "Oops:", err)
  os.Exit(1)
}
```