### PR TITLE
Use explicit packages in call lists

### DIFF
--- a/call_list.go
+++ b/call_list.go
@@ -61,14 +61,18 @@ func (c CallList) ContainsCallExpr(n ast.Node, ctx *Context) *ast.CallExpr {
 		return nil
 	}
 
-	// Try direct resolution
-	if c.Contains(selector, ident) {
-		return n.(*ast.CallExpr)
-	}
-
-	// Also support explicit path
+	// Use only explicit path to reduce conflicts
 	if path, ok := GetImportPath(selector, ctx); ok && c.Contains(path, ident) {
 		return n.(*ast.CallExpr)
 	}
+
+	/*
+		// Try direct resolution
+		if c.Contains(selector, ident) {
+			log.Printf("c.Contains == true, %s, %s.", selector, ident)
+			return n.(*ast.CallExpr)
+		}
+	*/
+
 	return nil
 }

--- a/call_list_test.go
+++ b/call_list_test.go
@@ -66,7 +66,7 @@ var _ = Describe("call list", func() {
 		ctx := pkg.CreateContext("md5.go")
 
 		// Search for md5.New()
-		calls.Add("md5", "New")
+		calls.Add("crypto/md5", "New")
 
 		// Stub out visitor and count number of matched call expr
 		matched := 0

--- a/rules/bind.go
+++ b/rules/bind.go
@@ -46,7 +46,7 @@ func (r *bindsToAllNetworkInterfaces) Match(n ast.Node, c *gas.Context) (*gas.Is
 func NewBindsToAllNetworkInterfaces(conf gas.Config) (gas.Rule, []ast.Node) {
 	calls := gas.NewCallList()
 	calls.Add("net", "Listen")
-	calls.Add("tls", "Listen")
+	calls.Add("crypto/tls", "Listen")
 	return &bindsToAllNetworkInterfaces{
 		calls:   calls,
 		pattern: regexp.MustCompile(`^(0.0.0.0|:).*$`),

--- a/rules/rsa.go
+++ b/rules/rsa.go
@@ -39,7 +39,7 @@ func (w *weakKeyStrength) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) 
 // NewWeakKeyStrength builds a rule that detects RSA keys < 2048 bits
 func NewWeakKeyStrength(conf gas.Config) (gas.Rule, []ast.Node) {
 	calls := gas.NewCallList()
-	calls.Add("rsa", "GenerateKey")
+	calls.Add("crypto/rsa", "GenerateKey")
 	bits := 2048
 	return &weakKeyStrength{
 		calls: calls,

--- a/rules/subproc.go
+++ b/rules/subproc.go
@@ -52,7 +52,7 @@ func (r *subprocess) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
 // NewSubproc detects cases where we are forking out to an external process
 func NewSubproc(conf gas.Config) (gas.Rule, []ast.Node) {
 	rule := &subprocess{gas.NewCallList()}
-	rule.Add("exec", "Command")
+	rule.Add("os/exec", "Command")
 	rule.Add("syscall", "Exec")
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}
 }

--- a/rules/tempfiles.go
+++ b/rules/tempfiles.go
@@ -39,7 +39,7 @@ func (t *badTempFile) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err erro
 // NewBadTempFile detects direct writes to predictable path in temporary directory
 func NewBadTempFile(conf gas.Config) (gas.Rule, []ast.Node) {
 	calls := gas.NewCallList()
-	calls.Add("ioutil", "WriteFile")
+	calls.Add("io/ioutil", "WriteFile")
 	calls.Add("os", "Create")
 	return &badTempFile{
 		calls: calls,

--- a/rules/templates.go
+++ b/rules/templates.go
@@ -41,10 +41,10 @@ func (t *templateCheck) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
 func NewTemplateCheck(conf gas.Config) (gas.Rule, []ast.Node) {
 
 	calls := gas.NewCallList()
-	calls.Add("template", "HTML")
-	calls.Add("template", "HTMLAttr")
-	calls.Add("template", "JS")
-	calls.Add("template", "URL")
+	calls.Add("html/template", "HTML")
+	calls.Add("html/template", "HTMLAttr")
+	calls.Add("html/template", "JS")
+	calls.Add("html/template", "URL")
 	return &templateCheck{
 		calls: calls,
 		MetaData: gas.MetaData{


### PR DESCRIPTION
By allowing partial matches of selectors there are chances of collisions
such as those in issue #145, this removes it to expect explicit packages
for each rule.

Closes #145