### PR TITLE
Do a single build for all packages

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -73,6 +73,28 @@ var _ = Describe("Analyzer", func() {
 			Expect(metrics.NumFiles).To(Equal(2))
 		})
 
+		It("should be able to analyze mulitple Go packages", func() {
+			analyzer.LoadRules(rules.Generate().Builders()...)
+			pkg1 := testutils.NewTestPackage()
+			pkg2 := testutils.NewTestPackage()
+			defer pkg1.Close()
+			defer pkg2.Close()
+			pkg1.AddFile("foo.go", `
+				package main
+				func main(){
+				}`)
+			pkg2.AddFile("bar.go", `
+				package main
+				func bar(){
+				}`)
+			pkg1.Build()
+			pkg2.Build()
+			err := analyzer.Process(pkg1.Path, pkg2.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, metrics := analyzer.Report()
+			Expect(metrics.NumFiles).To(Equal(2))
+		})
+
 		It("should find errors when nosec is not in use", func() {
 
 			// Rule for MD5 weak crypto usage

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -202,6 +201,7 @@ func main() {
 
 	vendor := regexp.MustCompile(`[\\/]vendor([\\/]|$)`)
 
+	var packages []string
 	// Iterate over packages on the import paths
 	for _, pkg := range gotool.ImportPaths(flag.Args()) {
 
@@ -209,12 +209,11 @@ func main() {
 		if vendor.MatchString(pkg) {
 			continue
 		}
+		packages = append(packages, pkg)
+	}
 
-		abspath, _ := filepath.Abs(pkg)
-		logger.Println("Searching directory:", abspath)
-		if err := analyzer.Process(pkg); err != nil {
-			logger.Fatal(err)
-		}
+	if err := analyzer.Process(packages...); err != nil {
+		logger.Fatal(err)
 	}
 
 	// Collect the results


### PR DESCRIPTION
This is much faster because the loader can reuse packages.