### PR TITLE
JUnit XML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ gas -nosec=true ./...
 
 ### Output formats
 
-Gas currently supports text, json and csv output formats. By default
+Gas currently supports text, json, csv and JUnit XML output formats. By default
 results will be reported to stdout, but can also be written to an output
 file. The output format is controlled by the '-fmt' flag, and the output file is controlled by the '-out' flag as follows:
 

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -59,7 +59,7 @@ var (
 	flagIgnoreNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
 
 	// format output
-	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, csv, html, or text")
+	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, csv, junit-xml, html, or text")
 
 	// output file
 	flagOutput = flag.String("out", "", "Set output file for results")

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -74,8 +74,8 @@ func CreateReport(w io.Writer, format string, issues []*gas.Issue, metrics *gas.
 		err = reportJSON(w, data)
 	case "csv":
 		err = reportCSV(w, data)
-	case "xml":
-		err = reportXML(w, data)
+	case "junit-xml":
+		err = reportJUnitXML(w, data)
 	case "html":
 		err = reportFromHTMLTemplate(w, html, data)
 	case "text":
@@ -118,7 +118,7 @@ func reportCSV(w io.Writer, data *reportInfo) error {
 	return nil
 }
 
-func reportXML(w io.Writer, data *reportInfo) error {
+func reportJUnitXML(w io.Writer, data *reportInfo) error {
 	groupedData := groupDataByRules(data)
 	junitXMLStruct := createJUnitXMLStruct(groupedData)
 

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -180,6 +180,7 @@ func reportXML(w io.Writer, data *reportInfo) error {
 		panic(err)
 	}
 
+	raw = append([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"), raw...)
 	_, err = w.Write(raw)
 	if err != nil {
 		panic(err)

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -122,7 +122,7 @@ func reportJUnitXML(w io.Writer, data *reportInfo) error {
 	groupedData := groupDataByRules(data)
 	junitXMLStruct := createJUnitXMLStruct(groupedData)
 
-	raw, err := xml.Marshal(junitXMLStruct)
+	raw, err := xml.MarshalIndent(junitXMLStruct, "", "\t")
 	if err != nil {
 		panic(err)
 	}

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -124,17 +124,17 @@ func reportJUnitXML(w io.Writer, data *reportInfo) error {
 
 	raw, err := xml.MarshalIndent(junitXMLStruct, "", "\t")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	xmlHeader := []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
 	raw = append(xmlHeader, raw...)
 	_, err = w.Write(raw)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func reportFromPlaintextTemplate(w io.Writer, reportTemplate string, data *reportInfo) error {

--- a/output/junit_xml_format.go
+++ b/output/junit_xml_format.go
@@ -1,0 +1,70 @@
+package output
+
+import (
+	"encoding/json"
+	"encoding/xml"
+
+	"github.com/GoASTScanner/gas"
+)
+
+type JUnitXMLReport struct {
+	XMLName    xml.Name    `xml:"testsuites"`
+	Testsuites []Testsuite `xml:"testsuite"`
+}
+
+type Testsuite struct {
+	XMLName   xml.Name   `xml:"testsuite"`
+	Name      string     `xml:"name,attr"`
+	Tests     int        `xml:"tests,attr"`
+	Testcases []Testcase `xml:"testcase"`
+}
+
+type Testcase struct {
+	XMLName xml.Name `xml:"testcase"`
+	Name    string   `xml:"name,attr"`
+	Failure Failure  `xml:"failure"`
+}
+
+type Failure struct {
+	XMLName xml.Name `xml:"failure"`
+	Message string   `xml:"message,attr"`
+	Text    string   `xml:",innerxml"`
+}
+
+func groupDataByRules(data *reportInfo) map[string][]*gas.Issue {
+	groupedData := make(map[string][]*gas.Issue)
+	for _, issue := range data.Issues {
+		if _, ok := groupedData[issue.What]; ok {
+			groupedData[issue.What] = append(groupedData[issue.What], issue)
+		} else {
+			groupedData[issue.What] = []*gas.Issue{issue}
+		}
+	}
+	return groupedData
+}
+
+func createJUnitXMLStruct(groupedData map[string][]*gas.Issue) JUnitXMLReport {
+	var xmlReport JUnitXMLReport
+	for what, issues := range groupedData {
+		testsuite := Testsuite{
+			Name:  what,
+			Tests: len(issues),
+		}
+		for _, issue := range issues {
+			stacktrace, err := json.MarshalIndent(issue, "", "\t")
+			if err != nil {
+				panic(err)
+			}
+			testcase := Testcase{
+				Name: issue.File,
+				Failure: Failure{
+					Message: "Found 1 vulnerability. See stacktrace for details.",
+					Text:    string(stacktrace),
+				},
+			}
+			testsuite.Testcases = append(testsuite.Testcases, testcase)
+		}
+		xmlReport.Testsuites = append(xmlReport.Testsuites, testsuite)
+	}
+	return xmlReport
+}

--- a/output/junit_xml_format.go
+++ b/output/junit_xml_format.go
@@ -1,8 +1,8 @@
 package output
 
 import (
-	"encoding/json"
 	"encoding/xml"
+	"strconv"
 
 	"github.com/GoASTScanner/gas"
 )
@@ -51,15 +51,17 @@ func createJUnitXMLStruct(groupedData map[string][]*gas.Issue) JUnitXMLReport {
 			Tests: len(issues),
 		}
 		for _, issue := range issues {
-			stacktrace, err := json.MarshalIndent(issue, "", "\t")
-			if err != nil {
-				panic(err)
-			}
+			text := "Results:\n"
+			text += "[" + issue.File + ":" + issue.Line + "] - " +
+				issue.What + " (Confidence: " + strconv.Itoa(int(issue.Confidence)) +
+				", Severity: " + strconv.Itoa(int(issue.Severity)) + ")\n"
+			text += "> " + issue.Code
+
 			testcase := Testcase{
 				Name: issue.File,
 				Failure: Failure{
 					Message: "Found 1 vulnerability. See stacktrace for details.",
-					Text:    string(stacktrace),
+					Text:    text,
 				},
 			}
 			testsuite.Testcases = append(testsuite.Testcases, testcase)

--- a/output/junit_xml_format.go
+++ b/output/junit_xml_format.go
@@ -31,7 +31,7 @@ type failure struct {
 	Text    string   `xml:",innerxml"`
 }
 
-func genereratePlaintext(issue *gas.Issue) string {
+func generatePlaintext(issue *gas.Issue) string {
 	return "Results:\n" +
 		"[" + issue.File + ":" + issue.Line + "] - " +
 		issue.What + " (Confidence: " + strconv.Itoa(int(issue.Confidence)) +
@@ -62,7 +62,7 @@ func createJUnitXMLStruct(groupedData map[string][]*gas.Issue) junitXMLReport {
 				Name: issue.File,
 				Failure: failure{
 					Message: "Found 1 vulnerability. See stacktrace for details.",
-					Text:    genereratePlaintext(issue),
+					Text:    generatePlaintext(issue),
 				},
 			}
 			testsuite.Testcases = append(testsuite.Testcases, testcase)


### PR DESCRIPTION
This PR creates a new output format, namely: `JUnit XML` format, following [IBM's definition](https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_9.5.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html).

This allows the results generated by `gas` to be used by CI tools, like Jenkins, which are able to parse/read `JUnit XML` results in their various workflows.

Example command to output `JUnit XML`:
```
gas -exclude=G104 -fmt=junit-xml -out=report.xml ./...
```

This PR is in reference to #158.