### PR TITLE
Escape html string for JUnit output

### DIFF
--- a/output/junit_xml_format.go
+++ b/output/junit_xml_format.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/xml"
+	htmlLib "html"
 	"strconv"
 
 	"github.com/GoASTScanner/gas"
@@ -35,7 +36,7 @@ func generatePlaintext(issue *gas.Issue) string {
 	return "Results:\n" +
 		"[" + issue.File + ":" + issue.Line + "] - " +
 		issue.What + " (Confidence: " + strconv.Itoa(int(issue.Confidence)) +
-		", Severity: " + strconv.Itoa(int(issue.Severity)) + ")\n" + "> " + issue.Code
+		", Severity: " + strconv.Itoa(int(issue.Severity)) + ")\n" + "> " + htmlLib.EscapeString(issue.Code)
 }
 
 func groupDataByRules(data *reportInfo) map[string][]*gas.Issue {


### PR DESCRIPTION
`issue.Code` can contain `html` tags/characters, thus causing the parsing/reading of the JUnit XML output  in another component to fail.

Fixed by escaping `html` strings.