### PR TITLE
Sort the issues by severity in descending order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: go
 before_script:
   - go vet $(go list ./... | grep -v /vendor/)
 go:
-  - 1.5
+  - 1.7
+  - 1.8
+  - 1.9
   - tip
 install:
   - go get -v github.com/onsi/ginkgo/ginkgo

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -236,7 +236,7 @@ func main() {
 
 	// Sort the issue by severity
 	if *flagSortIssues {
-		sort.Slice(issues, func(i, j int) bool { return (issues[i].Severity > issues[j].Severity) })
+		sortIssues(issues)
 	}
 
 	// Create output report

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -79,6 +79,9 @@ var (
 	// log to file or stderr
 	flagLogfile = flag.String("log", "", "Log messages to file rather than stderr")
 
+	// sort the issues by severity
+	flagSortIssues = flag.Bool("sort", true, "Sort issues by severity")
+
 	logger *log.Logger
 )
 
@@ -229,6 +232,11 @@ func main() {
 	// Exit quietly if nothing was found
 	if !issuesFound && *flagQuiet {
 		os.Exit(0)
+	}
+
+	// Sort the issue by severity
+	if *flagSortIssues {
+		sort.Slice(issues, func(i, j int) bool { return (issues[i].Severity > issues[j].Severity) })
 	}
 
 	// Create output report

--- a/cmd/gas/sort_issues.go
+++ b/cmd/gas/sort_issues.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/GoASTScanner/gas"
+)
+
+type sortBySeverity []*gas.Issue
+
+func (s sortBySeverity) Len() int { return len(s) }
+
+func (s sortBySeverity) Less(i, j int) bool { return s[i].Severity > s[i].Severity }
+
+func (s sortBySeverity) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// sortIssues sorts the issues by severity in descending order
+func sortIssues(issues []*gas.Issue) {
+	sort.Sort(sortBySeverity(issues))
+}


### PR DESCRIPTION
Sort the issues by severity in descending order before creating the report. This will print the most critical issues at the top of the report. 

This is useful when doing security audit in large code bases with hundred of warnings. 

cc @gcmurphy 