### PR TITLE
Make the folder permissions more permissive to avoid false positives

### DIFF
--- a/rules/fileperms.go
+++ b/rules/fileperms.go
@@ -75,7 +75,7 @@ func NewFilePerms(conf gas.Config) (gas.Rule, []ast.Node) {
 // NewMkdirPerms creates a rule to detect directory creation with more permissive than
 // configured permission mask.
 func NewMkdirPerms(conf gas.Config) (gas.Rule, []ast.Node) {
-	mode := getConfiguredMode(conf, "G301", 0700)
+	mode := getConfiguredMode(conf, "G301", 0750)
 	return &filePermissions{
 		mode:  mode,
 		pkg:   "os",


### PR DESCRIPTION
I would make the folder permissions a bit more permissive than `0700`. This is a bit too strict and it produces too many false positives. For instance, large projects such as Kubernetes has adopted `0750` as default permissions.

cc @gcmurphy 