### PR TITLE
Support package resolution and filepaths

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -108,6 +108,10 @@ func (gas *Analyzer) Process(packagePaths ...string) error {
 		if err != nil {
 			return err
 		}
+		if _, err := os.Stat(abspath); os.IsNotExist(err) {
+			gas.logger.Printf("Skipping: %s. Path doesn't exist.", abspath)
+			continue
+		}
 		gas.logger.Println("Searching directory:", abspath)
 
 		basePackage, err := build.Default.ImportDir(packagePath, build.ImportComment)

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -193,12 +193,9 @@ func cleanPaths(paths []string) []string {
 	projectRoot := filepath.FromSlash(fmt.Sprintf("%s/src/", gopath()))
 	var clean []string
 	for _, arg := range paths {
-		cleanPath, err := filepath.Abs(arg)
-		if err != nil {
-			cleanPath = arg
-		}
-		if strings.HasPrefix(arg, projectRoot) {
-			clean = append(clean, strings.TrimPrefix(arg, projectRoot))
+		absPath, _ := filepath.Abs(arg)
+		if strings.HasPrefix(absPath, projectRoot) {
+			clean = append(clean, strings.TrimPrefix(absPath, projectRoot))
 		} else {
 			clean = append(clean, arg)
 		}

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -194,9 +194,9 @@ func cleanPaths(paths []string) []string {
 	var clean []string
 	for _, arg := range paths {
 		abspath, err := filepath.Abs(arg)
-        if err != nil {
-            abspath = arg
-        }
+		if err != nil {
+			abspath = arg
+		}
 		if strings.HasPrefix(abspath, projectRoot) {
 			clean = append(clean, strings.TrimPrefix(abspath, projectRoot))
 		} else {

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -193,9 +193,12 @@ func cleanPaths(paths []string) []string {
 	projectRoot := filepath.FromSlash(fmt.Sprintf("%s/src/", gopath()))
 	var clean []string
 	for _, arg := range paths {
-		absPath, _ := filepath.Abs(arg)
-		if strings.HasPrefix(absPath, projectRoot) {
-			clean = append(clean, strings.TrimPrefix(absPath, projectRoot))
+		abspath, err := filepath.Abs(arg)
+        if err != nil {
+            abspath = arg
+        }
+		if strings.HasPrefix(abspath, projectRoot) {
+			clean = append(clean, strings.TrimPrefix(abspath, projectRoot))
 		} else {
 			clean = append(clean, arg)
 		}


### PR DESCRIPTION
This change introduces the logic to resolve packages using gotool
and build packages from filepaths. It assumes that the packages
being scanned are located within the GOPATH.

If the GOPATH environment variable is not set the GOPATH is derived
as $HOME/go.

Relates to #184