### PR TITLE
Fix up some mistakes in the README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,12 @@ $ gas -fmt=json -out=results.json *.go
 ```
 ### Development
 
-#### Build
+#### Prerequisites
 
+Install dep according to the instructions here: https://github.com/golang/dep
+Install the latest version of golint: https://github.com/golang/lint
+
+#### Build
 
 ```
 make
@@ -126,7 +130,7 @@ make
 #### Tests
 
 ```
-make tests
+make test
 ```
 
 #### Release Build


### PR DESCRIPTION
This fixes a couple issues found in the README in the development
section:
* There was no information provided on dependencies.  Both go/dep
  and golint are required to run make.
* To run the tests, the command 'make test' not 'make tests' has
  to be used.