### PR TITLE
Add rule ID to default text output template

### DIFF
--- a/output/formatter.go
+++ b/output/formatter.go
@@ -45,7 +45,7 @@ const (
 
 var text = `Results:
 {{ range $index, $issue := .Issues }}
-[{{ $issue.File }}:{{ $issue.Line }}] - {{ $issue.What }} (Confidence: {{ $issue.Confidence}}, Severity: {{ $issue.Severity }})
+[{{ $issue.File }}:{{ $issue.Line }}] - {{ $issue.RuleID }}: {{ $issue.What }} (Confidence: {{ $issue.Confidence}}, Severity: {{ $issue.Severity }})
   > {{ $issue.Code }}
 
 {{ end }}


### PR DESCRIPTION
Since rule IDs are now available (#188), it would be nice for newbies to be able to see them in the default text output and correlate back to documentation.

Before:
```
[.../database.go:266] - Errors unhandled. (Confidence: HIGH, Severity: LOW)
  > scope.SetColumn(x.DBName, encoded)
```

After:
```
[.../database.go:266] - G104: Errors unhandled. (Confidence: HIGH, Severity: LOW)
  > scope.SetColumn(x.DBName, encoded)
```

This makes it easier to write annotations using `#nosec:RuleID` as well.