### PR TITLE
Add an option for Go build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ can do the following:
 ```
 $ gas -nosec=true ./...
 ```
+#### Build tags
+
+Gas is able to pass your [Go build tags](https://golang.org/pkg/go/build/) to the analyzer.
+They can be provided as a comma separated list as follows:
+
+```
+$ gas -tag debug,ignore ./...
+```
 
 ### Output formats
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -97,9 +97,11 @@ func (gas *Analyzer) LoadRules(ruleDefinitions map[string]RuleBuilder) {
 }
 
 // Process kicks off the analysis process for a given package
-func (gas *Analyzer) Process(packagePaths ...string) error {
+func (gas *Analyzer) Process(buildTags []string, packagePaths ...string) error {
+	ctx := build.Default
+	ctx.BuildTags = append(ctx.BuildTags, buildTags...)
 	packageConfig := loader.Config{
-		Build:       &build.Default,
+		Build:       &ctx,
 		ParserMode:  parser.ParseComments,
 		AllowErrors: true,
 	}

--- a/cmd/gas/main.go
+++ b/cmd/gas/main.go
@@ -90,6 +90,9 @@ var (
 	// sort the issues by severity
 	flagSortIssues = flag.Bool("sort", true, "Sort issues by severity")
 
+	// go build tags
+	flagBuildTags = flag.String("tags", "", "Comma separated list of build tags")
+
 	logger *log.Logger
 )
 
@@ -313,7 +316,11 @@ func main() {
 		packages = append(packages, resolvePackage(pkg, gopaths))
 	}
 
-	if err := analyzer.Process(packages...); err != nil {
+	var buildTags []string
+	if *flagBuildTags != "" {
+		buildTags = strings.Split(*flagBuildTags, ",")
+	}
+	if err := analyzer.Process(buildTags, packages...); err != nil {
 		logger.Fatal(err)
 	}
 

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -15,10 +15,11 @@ import (
 var _ = Describe("gas rules", func() {
 
 	var (
-		logger   *log.Logger
-		config   gas.Config
-		analyzer *gas.Analyzer
-		runner   func(string, []testutils.CodeSample)
+		logger    *log.Logger
+		config    gas.Config
+		analyzer  *gas.Analyzer
+		runner    func(string, []testutils.CodeSample)
+		buildTags []string
 	)
 
 	BeforeEach(func() {
@@ -34,7 +35,7 @@ var _ = Describe("gas rules", func() {
 				pkg.AddFile(fmt.Sprintf("sample_%d.go", n), sample.Code)
 				err := pkg.Build()
 				Expect(err).ShouldNot(HaveOccurred())
-				err = analyzer.Process(pkg.Path)
+				err = analyzer.Process(buildTags, pkg.Path)
 				Expect(err).ShouldNot(HaveOccurred())
 				issues, _ := analyzer.Report()
 				if len(issues) != sample.Errors {

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -721,4 +721,12 @@ import (
 func main() {
 	cgi.Serve(http.FileServer(http.Dir("/usr/share/doc")))
 }`, 1}}
+	// SampleCode601 - Go build tags
+	SampleCode601 = []CodeSample{{`
+// +build test
+
+package main
+func main() {
+  fmt.Println("no package imported error")
+}`, 1}}
 )


### PR DESCRIPTION
Add an option to Go build tags (https://golang.org/pkg/go/build/)

@Fixes #157 

cc @gcmurphy 